### PR TITLE
Add base typography

### DIFF
--- a/core/static/css/base.css
+++ b/core/static/css/base.css
@@ -16,15 +16,6 @@
     --color-pp-pale-grey: #d8d8d8;
     --color-pp-dark-grey: #55585a;
     --color-pp-almost-black: #1a1c1a;
-
-    /* REM values can used for marging, padding, etc */
-    --rem-small: 0.8rem;
-    --rem-base: 1rem;
-    --rem-md: 1.2rem;
-    --rem-lg: 1.5rem;
-    --rem-xl: 1.7rem;
-    --rem-2xl: 2rem;
-    --rem-3xl: 2.25rem;
 }
 
 /* Site's default element level styling */
@@ -76,11 +67,11 @@
     }
 
     h1, h2, h3, h4, h5, h6 {
-        @apply mt-(--rem-xl) mb-(--rem-base) font-medium tracking-tight;
+        @apply mt-7 mb-4 font-medium tracking-tight;
     }
 
     p {
-        @apply my-(--rem-base)
+        @apply my-4
     }
 }
 


### PR DESCRIPTION
### 📋 Summary
<!-- Briefly describe WHAT and WHY of this PR -->
This PR adds base typography (font size, weight, margin) for the header and paragraph text. This base/default styling will be used when individual / utility level styling is not done.
 
### 🛠️ Changes Made
<!-- One-liners or bullet points -->
- Added base typography styling for header and paragraph tags in the `base` layer.
 
### ✅ Checklist
- [x] Assignee is selected
- [x] Code and content adhere to [conventions](https://scilifelab.atlassian.net/wiki/spaces/CDP2/pages/1909424133/Guidelines+for+the+portal+content)
- [x] Automated checks pass
- [x] Reviewer is selected when the PR is marked as ready for review
