### PR TITLE
Fix base container margin and remove tailwind's base layer

### DIFF
--- a/core/static/css/base.css
+++ b/core/static/css/base.css
@@ -3,8 +3,11 @@
 /* Import fonts */
 @import url("https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:ital,wght@0,200;0,400;0,500;0,700;1,400&display=swap");
 
-/* Tailwind CSS import */
-@import "tailwindcss";
+/* Tailwind CSS import (without Tailwind's base) */
+@layer theme, base, components, utilities;
+
+@import "tailwindcss/theme.css" layer(theme);
+@import "tailwindcss/utilities.css" layer(utilities);
 
 /* Custom variable and styling values */
 @theme {


### PR DESCRIPTION
### 📋 Summary
<!-- Briefly describe WHAT and WHY of this PR -->

Tailwind css has inbuilt `container` class (under `utility` layer), so explicitly setting margin is messing the layout. Setting `mx-auto` centres the container as expected.

`@import "tailwindcss"` imports tailwind's base layer too (ref [doc](https://tailwindcss.com/docs/preflight#disabling-preflight)). Its is better to not include it as we have our own base, and thus less chances of conflict and confusion. So we only wanna import Tailwind's `theme` and `utilities`.

<!-- Tips, edge cases, or test instructions -->
 
### ✅ Checklist
- [x] Assignee is selected
- [x] Code and content adhere to [conventions](https://scilifelab.atlassian.net/wiki/spaces/CDP2/pages/1909424133/Guidelines+for+the+portal+content)
- [x] Automated checks pass
- [x] Reviewer is selected when the PR is marked as ready for review

