### PR TITLE
Remove text decoration for image link

### DIFF
--- a/core/templates/header.html
+++ b/core/templates/header.html
@@ -4,7 +4,7 @@
 
     <!-- Logo -->
     <div class="container">
-      <a href="{% url 'home' %}" class="mr-5">
+      <a href="{% url 'home' %}" class="mr-5 no-underline">
         <img class="h-15 inline" src="{% static 'images/swe_pathogens_logo.svg' %}" alt="Pathogens Portal Sweden">
       </a>
       <a href="https://www.scilifelab.se">


### PR DESCRIPTION
### 📋 Summary
<!-- Briefly describe WHAT and WHY of this PR -->
while hovering over portal logo, the text decoration of '\<a\>' tag shows up at the end of the image. Adding ` no-underline` disables it.
 
### ✅ Checklist
- [x] Assignee is selected
- [x] Code and content adhere to [conventions](https://scilifelab.atlassian.net/wiki/spaces/CDP2/pages/1909424133/Guidelines+for+the+portal+content)
- [x] Automated checks pass
- [x] Reviewer is selected when the PR is marked as ready for review
