### PR TITLE
Add app_name in the url.py

### DIFF
--- a/core/templates/header.html
+++ b/core/templates/header.html
@@ -4,7 +4,7 @@
 
     <!-- Logo -->
     <div class="container my-4">
-      <a href="{% url 'home' %}" class="mr-5 no-underline">
+      <a href="{% url 'home:index' %}" class="mr-5 no-underline">
         <img class="h-15 inline" src="{% static 'images/swe_pathogens_logo.svg' %}" alt="Pathogens Portal Sweden">
       </a>
       <a href="https://www.scilifelab.se">

--- a/pages/home/urls.py
+++ b/pages/home/urls.py
@@ -1,6 +1,8 @@
 from django.urls import path
 from .views import Home
 
+app_name = "home"
+
 urlpatterns = [
-    path("", Home.as_view(), name="home"),
+    path("", Home.as_view(), name="index"),
 ]

--- a/pages/privacy/urls.py
+++ b/pages/privacy/urls.py
@@ -1,6 +1,8 @@
 from django.urls import path
 from .views import Privacy
 
+app_name = "privacy"
+
 urlpatterns = [
-    path("", Privacy.as_view(), name="privacy"),
+    path("", Privacy.as_view(), name="index"),
 ]


### PR DESCRIPTION
### 📋 Summary
<!-- Briefly describe WHAT and WHY of this PR -->
Add `app_name` in the individual app's `url.py`, so the app's urls defined in that file will be added to the name space (defined by `app_name`). This is good practice, so we don't have to worry about other URLs defined in other app's have the same URL name or not.

So while using the URL name in the functions like `url` or `reverse`, one should use `<name_space>:<url_name>`. So for example, to refer home's apps landing page in a template, one would use `{% url 'home:index' %}`
 
### 🛠️ Changes Made
<!-- One-liners or bullet points -->
- Added `app_name` to all apps `urls.py`
- Renamed app's landing paging name to `index` to keep it consistent
 
### ✅ Checklist
- [x] Assignee is selected
- [x] Code and content adhere to [conventions](https://scilifelab.atlassian.net/wiki/spaces/CDP2/pages/1909424133/Guidelines+for+the+portal+content)
- [x] Automated checks pass
- [x] Reviewer is selected when the PR is marked as ready for review
