### PR TITLE
FREYA-1740: Add a workflow to build Docker Images

### DIFF
--- a/.github/workflows/publish_image.yaml
+++ b/.github/workflows/publish_image.yaml
@@ -12,6 +12,9 @@ jobs:
     if: github.repository == 'scilifelabdatacentre/swedish-pathogens-portal'
     name: Publish Docker image
     runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.ref }}-docker-build
+      cancel-in-progress: true 
     permissions:
       contents: read
       packages: write
@@ -31,11 +34,11 @@ jobs:
           images: ghcr.io/scilifelabdatacentre/swedish-pathogens-portal
           tags: |
              type=sha,format=long
+             type=sha,prefix={{branch}}-
              type=ref,event=branch
              type=semver,pattern={{version}}
              type=semver,pattern={{major}}.{{minor}}
              type=semver,pattern={{major}}
-             type=sha,prefix={{branch}}-
       - name: Build and publish backend
         uses: docker/build-push-action@v6
         with:


### PR DESCRIPTION
### 📋 Summary
<!-- Briefly describe WHAT and WHY of this PR -->
This PR sets up a Github action to atumatically build a new image after each push to `main`
 
### 🛠️ Changes Made
<!-- One-liners or bullet points -->
- Added `publish_container.yaml`

### 🔍 Notes for Reviewers
<!-- Tips, edge cases, or test instructions -->
 
### ✅ Checklist
- [x] PR title follows the pattern: `FREYA-XXXX: Clear and short description`
- [x] Jira / Github issue is linked in description
- [x] Assignee is selected
- [x] Code and content adhere to [conventions](https://scilifelab.atlassian.net/wiki/spaces/CDP2/pages/1909424133/Guidelines+for+the+portal+content)
- [x] Automated checks pass
- [x] Reviewer is selected when the PR is marked as ready for review

### 🔗 Jira Issue
Closes: [FREYA-1740](https://scilifelab.atlassian.net/browse/FREYA-FREYA-1740)
