### PR TITLE
FREYA-1680: Add SARS-CoV-2 Variant Competition dashboard

### DIFF
--- a/pages/dashboards/templates/dashboards/index.html
+++ b/pages/dashboards/templates/dashboards/index.html
@@ -7,9 +7,14 @@
     </span>
     
     <h4>Available dashboards</h4>
-    <!-- 
-    For now, maually add a hyperlink to your dashboard if you need a quick reference
+    {% comment %}
+    For now, maually add a hyperlink to your dashboard in the list if you need a quick reference
+    For example: <a href="{% url 'dashboards:url-name' %}">Dashboard name</a>
+    {% endcomment %}
 
-    For example: <a href="/dashboards/<my-dashboard>">Wastewater SLU</a>
-    -->
+    <ul class="list-disc pl-6 mt-2">
+        <li>
+            <a href="{% url 'dashboards:lineage_competition' %}">SARS-CoV-2 Variant Competition</a>
+        </li>
+    </ul>
 {% endblock %}

--- a/pages/dashboards/templates/dashboards/lineage_competition.html
+++ b/pages/dashboards/templates/dashboards/lineage_competition.html
@@ -1,104 +1,169 @@
 {% extends "base.html" %}
 
 {% block content %}
-    <div class="prose max-w-none">
-        <div class="bg-blue-50 border-l-4 border-blue-400 text-blue-800 p-4 my-6" role="status">
-            <p class="m-0"><strong>All data last updated:</strong> TODO</p>
+    <a href="#content-start" class="sr-only focus:not-sr-only focus:outline-none focus:ring-2 focus:ring-pp-mid-blue px-3 py-2 bg-white">Skip to content</a>
+    <h1 class="sr-only">SARS-CoV-2 Variant Competition</h1>
+    <div id="content-start">
+        <div class="prose max-w-none space-y-6 mt-4">
+            <div class="bg-pp-pale-grey/30 border-l-4 border-pp-mid-blue text-pp-dark-blue p-4" role="status">
+                <p class="m-0"><strong>All data last updated:</strong> TODO</p>
+            </div>
+
+            <p>
+                SARS-CoV-2 is constantly evolving, with new variants competing against one another for domiance in
+                different regions. This model integrates SARS-CoV-2 genotype sequencing data from around the world to
+                estimate the growth advantage of different variants, which is then used to provide regional estimates of
+                variant frequencies and how these are changing over time. This can be used by researchers who might
+                wish to know which variants to focus on in their studies, or by public health officials who might wish
+                to know which variants are likely to become dominant in their region.
+            </p>
+
+            <p>
+                The full set of model estimates, which includes estimates for countries other than Sweden, can be found
+                in the <a href="https://github.com/MurrellGroup/lineages">GitHub repository of the Murrell research
+                group</a>, who conduct this research.
+            </p>
+
+            <h2 id="global-statistics">Global statistics on lineage competition</h2>
+
+            <h3 id="advantage-estimates">Advantage estimates</h3>
+
+            <p>
+                Growth rate advantages are estimated from all variant frequency data, globally. A variant with a higher
+                growth rate advantage is expected to increase in frequency relative to other variants.
+            </p>
+
+            <figure class="my-6">
+                <img alt="Growth advantage estimates for the top variants"
+                     src="https://raw.githubusercontent.com/MurrellGroup/lineages/main/plots/pruned_lineages_MCMC_lineage_growths.svg"
+                     class="mx-auto max-w-[1000px] w-full h-auto" />
+            </figure>
+
+            <p>
+                For convergent mutations (occuring independently at least three times), the contribution to the growth
+                rate advantage of each mutation is estimated.
+            </p>
+
+            <figure class="my-6">
+                <img alt="Estimates of contribution to growth of convergently occuring mutations"
+                     src="https://raw.githubusercontent.com/MurrellGroup/lineages/main/plots/N_MCMC_mutations.svg"
+                     class="mx-auto max-w-[1000px] w-full h-auto" />
+            </figure>
+
+            <p>
+                The relatedness of SARS-CoV-2 variants, with their estimated growth rate advantages, can be visualised
+                in a phylogenetic tree. Only recent variants, and key ancestral variants, are shown. Lineages with low
+                growth rate estimates are excluded.
+            </p>
+
+            <figure class="my-6">
+                <img alt="Growth-annotated phylogeny"
+                     src="https://raw.githubusercontent.com/MurrellGroup/lineages/main/plots/tree_pruned.svg"
+                     class="mx-auto max-w-[1000px] w-full h-auto" />
+            </figure>
+
+            <h3 id="variant-trajectories">Variant trajectories</h3>
+
+            <p>
+                The "model average" variant frequencies are forecasts from the model with all region-specific effects
+                set to zero. This provides a single "snapshot" of the global variant situation. This is not meant to
+                representative of the true global variant frequencies, since it is influenced by different sequencing
+                coverage in different regions, but it is useful to understand the model's estimates of how quickly one
+                variant might be expected to replace others.
+            </p>
+
+            <p>
+                Variants are coloured such that related variants should be similar in colour.
+            </p>
+
+            <figure class="my-6">
+                <img alt="Model average variant trajectories"
+                     src="https://raw.githubusercontent.com/MurrellGroup/lineages/main/plots/variant_trajectories_model_avg.svg"
+                     class="mx-auto max-w-[1000px] w-full h-auto" />
+            </figure>
+
+            <figure class="my-6">
+                <img alt="Model average variant frequencies"
+                     src="https://raw.githubusercontent.com/MurrellGroup/lineages/main/plots/muller_trajectories_model_avg.svg"
+                     class="mx-auto max-w-[1000px] w-full h-auto" />
+            </figure>
+
+            <h2 id="results-sweden">Results from Sweden</h2>
+
+            <p>
+                Estimates of variant frequencies and growth rate advantages for Sweden are always included in the model.
+                As with all data used in the model, Swedish genotype data comes from <a href="https://gisaid.org">GISAID</a>.
+                Sequencing volumes are often low for Sweden, especially when the case counts themselves are low (and
+                there are not many infections to sequence). In such cases, the estimates for variant frequencies in
+                Sweden can be very uncertain. It is therefore important to treat the results of the model with caution
+                when sequencing volumes are low.
+            </p>
+
+            <figure class="my-6">
+                <img alt="SARS-CoV-2 genotype volumes"
+                     src="https://raw.githubusercontent.com/MurrellGroup/lineages/main/plots/sequence_volume_Sweden.svg"
+                     class="mx-auto max-w-[1000px] w-full h-auto" />
+            </figure>
+
+            <figure class="my-6">
+                <img alt="Variant trajectories in Sweden"
+                     src="https://raw.githubusercontent.com/MurrellGroup/lineages/main/plots/variant_trajectories_Sweden.svg"
+                     class="mx-auto max-w-[1000px] w-full h-auto" />
+            </figure>
+
+            <figure class="my-6">
+                <img alt="Variant frequencies in Sweden"
+                     src="https://raw.githubusercontent.com/MurrellGroup/lineages/main/plots/muller_trajectories_country_Sweden.svg"
+                     class="mx-auto max-w-[1000px] w-full h-auto" />
+            </figure>
+
+            <h2 id="methods">Methods</h2>
+
+            <p>
+                Lineage dynamics are modelled using a Bayesian multinomial logistic regression over lineage counts. The
+                latest global <a href="https://gisaid.org/">GISAID</a> SARS-CoV-2 dataset (obtained via bulk download)
+                is filtered to include only sequences with collection dates within the last 100 days. Lineage assignment
+                is performed using <a href="https://docs.nextstrain.org/projects/nextclade/en/stable/user/nextclade-cli/index.html">NextClade</a>,
+                retaining sequences with a “good” overall quality control (QC) status, and >90% coverage. Daily lineage
+                counts are aggregated by region (including only countries with sufficient recent sequencing volumes),
+                with low-frequency sub-lineages (too rare to model) merged into their most recent ancestors.
+            </p>
+
+            <p>
+                Growth rates are modelled with a hierarchical approach. Each lineage's growth rate in a given region is
+                the sum of a global rate and a region-specific random effect. The global rate for each lineage comprises
+                three components: i) branch-specific terms for each branch ancestral to the lineage, ii) terms for
+                convergent spike mutations occurring 3 or more times independently that are present in the lineage, and
+                iii) a lineage-specific term. This parameterisation allows for shared evidence when mutations occur
+                across multiple branches, and phylogenetic heritability of growth rates, such that growth rates for
+                closely-related lineages are more likely, under the model’s prior, to be similar to one another.
+                Recombinants inherit weighted mixtures of their multiple parents' growth terms. Lineage-specific
+                intercept terms, which control the relative timing of the emergence of variants, comprise a global
+                shared term and region-specific random effects.
+            </p>
+
+            <p>
+                Gaussian priors (centred on zero) are used for each parameter type, with Gaussian hyperpriors over the
+                log of their standard deviations. Posterior distributions are jointly sampled (for global and local
+                parameters for all global data) using Hamiltonian Monte Carlo with the No-U-Turn sampler, implemented in
+                the <a href="https://github.com/TuringLang/AdvancedHMC.jl">AdvancedHMC.jl</a> package of
+                <a href="https://julialang.org/">Julia</a>.
+            </p>
+
+            <p>
+                The <a href="https://github.com/cov-lineages/pango-designation/">Pango designations</a> are used for
+                lineage names in all of the plots produced using the model.
+            </p>
+
+            <h2 id="acknowledgement-note">Acknowledgement note</h2>
+
+            <p>
+                The Murrell group gratefully acknowledges all data contributors, i.e. the Authors and their Originating
+                Laboratories responsible for obtaining the specimens, and their Submitting Laboratories that generated
+                the genetic sequence and metadata and shared via the GISAID Initiative the data on which this research is
+                based.
+            </p>
         </div>
-
-        <p>
-            SARS-CoV-2 is constantly evolving, with new variants competing against one another for domiance in different regions. This model integrates SARS-CoV-2 genotype sequencing data from around the world to estimate the growth advantage of different variants, which is then used to provide regional estimates of variant frequencies and how these are changing over time. This can be used by researchers who might wish to know which variants to focus on in their studies, or by public health officials who might wish to know which variants are likely to become dominant in their region.
-        </p>
-
-        <p>
-            The full set of model estimates, which includes estimates for countries other than Sweden, can be found in the <a href="https://github.com/MurrellGroup/lineages">GitHub repository of the Murrell research group</a>, who conduct this research.
-        </p>
-
-        <h2>Global statistics on lineage competition</h2>
-
-        <h3>Advantage estimates</h3>
-
-        <p>
-            Growth rate advantages are estimated from all variant frequency data, globally. A variant with a higher growth rate advantage is expected to increase in frequency relative to other variants.
-        </p>
-
-        <figure class="my-6">
-            <img alt="Growth advantage estimates for the top variants" src="https://raw.githubusercontent.com/MurrellGroup/lineages/main/plots/pruned_lineages_MCMC_lineage_growths.svg" class="mx-auto max-w-[1000px] w-full h-auto" />
-        </figure>
-
-        <p>
-            For convergent mutations (occuring independently at least three times), the contribution to the growth rate advantage of each mutation is estimated.
-        </p>
-
-        <figure class="my-6">
-            <img alt="Estimates of contribution to growth of convergently occuring mutations" src="https://raw.githubusercontent.com/MurrellGroup/lineages/main/plots/N_MCMC_mutations.svg" class="mx-auto max-w-[1000px] w-full h-auto" />
-        </figure>
-
-        <p>
-            The relatedness of SARS-CoV-2 variants, with their estimated growth rate advantages, can be visualised in a phylogenetic tree. Only recent variants, and key ancestral variants, are shown. Lineages with low growth rate estimates are excluded.
-        </p>
-
-        <figure class="my-6">
-            <img alt="Growth-annotated phylogeny" src="https://raw.githubusercontent.com/MurrellGroup/lineages/main/plots/tree_pruned.svg" class="mx-auto max-w-[1000px] w-full h-auto" />
-        </figure>
-
-        <h3>Variant trajectories</h3>
-
-        <p>
-            The "model average" variant frequencies are forecasts from the model with all region-specific effects set to zero. This provides a single "snapshot" of the global variant situation. This is not meant to representative of the true global variant frequencies, since it is influenced by different sequencing coverage in different regions, but it is useful to understand the model's estimates of how quickly one variant might be expected to replace others.
-        </p>
-
-        <p>
-            Variants are coloured such that related variants should be similar in colour.
-        </p>
-
-        <figure class="my-6">
-            <img alt="Model average variant trajectories" src="https://raw.githubusercontent.com/MurrellGroup/lineages/main/plots/variant_trajectories_model_avg.svg" class="mx-auto max-w-[1000px] w-full h-auto" />
-        </figure>
-
-        <figure class="my-6">
-            <img alt="Model average variant frequencies" src="https://raw.githubusercontent.com/MurrellGroup/lineages/main/plots/muller_trajectories_model_avg.svg" class="mx-auto max-w-[1000px] w-full h-auto" />
-        </figure>
-
-        <h2>Results from Sweden</h2>
-
-        <p>
-            Estimates of variant frequencies and growth rate advantages for Sweden are always included in the model. As with all data used in the model, Swedish genotype data comes from <a href="https://gisaid.org">GISAID</a>. Sequencing volumes are often low for Sweden, especially when the case counts themselves are low (and there are not many infections to sequence). In such cases, the estimates for variant frequencies in Sweden can be very uncertain. It is therefore important to treat the results of the model with caution when sequencing volumes are low.
-        </p>
-
-        <figure class="my-6">
-            <img alt="SARS-CoV-2 genotype volumes" src="https://raw.githubusercontent.com/MurrellGroup/lineages/main/plots/sequence_volume_Sweden.svg" class="mx-auto max-w-[1000px] w-full h-auto" />
-        </figure>
-
-        <figure class="my-6">
-            <img alt="Variant trajectories in Sweden" src="https://raw.githubusercontent.com/MurrellGroup/lineages/main/plots/variant_trajectories_Sweden.svg" class="mx-auto max-w-[1000px] w-full h-auto" />
-        </figure>
-
-        <figure class="my-6">
-            <img alt="Variant frequencies in Sweden" src="https://raw.githubusercontent.com/MurrellGroup/lineages/main/plots/muller_trajectories_country_Sweden.svg" class="mx-auto max-w-[1000px] w-full h-auto" />
-        </figure>
-
-        <h2>Methods</h2>
-
-        <p>
-            Lineage dynamics are modelled using a Bayesian multinomial logistic regression over lineage counts. The latest global <a href="https://gisaid.org/">GISAID</a> SARS-CoV-2 dataset (obtained via bulk download) is filtered to include only sequences with collection dates within the last 100 days. Lineage assignment is performed using <a href="https://docs.nextstrain.org/projects/nextclade/en/stable/user/nextclade-cli/index.html">NextClade</a>, retaining sequences with a “good” overall quality control (QC) status, and >90% coverage. Daily lineage counts are aggregated by region (including only countries with sufficient recent sequencing volumes), with low-frequency sub-lineages (too rare to model) merged into their most recent ancestors.
-        </p>
-
-        <p>
-            Growth rates are modelled with a hierarchical approach. Each lineage's growth rate in a given region is the sum of a global rate and a region-specific random effect. The global rate for each lineage comprises three components: i) branch-specific terms for each branch ancestral to the lineage, ii) terms for convergent spike mutations occurring 3 or more times independently that are present in the lineage, and iii) a lineage-specific term. This parameterisation allows for shared evidence when mutations occur across multiple branches, and phylogenetic heritability of growth rates, such that growth rates for closely-related lineages are more likely, under the model’s prior, to be similar to one another. Recombinants inherit weighted mixtures of their multiple parents' growth terms. Lineage-specific intercept terms, which control the relative timing of the emergence of variants, comprise a global shared term and region-specific random effects.
-        </p>
-
-        <p>
-            Gaussian priors (centred on zero) are used for each parameter type, with Gaussian hyperpriors over the log of their standard deviations. Posterior distributions are jointly sampled (for global and local parameters for all global data) using Hamiltonian Monte Carlo with the No-U-Turn sampler, implemented in the <a href="https://github.com/TuringLang/AdvancedHMC.jl">AdvancedHMC.jl</a> package of <a href="https://julialang.org/">Julia</a>.
-        </p>
-
-        <p>
-            The <a href="https://github.com/cov-lineages/pango-designation/">Pango designations</a> are used for lineage names in all of the plots produced using the model.
-        </p>
-
-        <p>
-            The Murrell group gratefully acknowledges all data contributors, i.e. the Authors and their Originating Laboratories responsible for obtaining the specimens, and their Submitting Laboratories that generated the genetic sequence and metadata and shared via the GISAID Initiative the data on which this research is based.
-        </p>
     </div>
 {% endblock %}
 

--- a/pages/dashboards/templates/dashboards/lineage_competition.html
+++ b/pages/dashboards/templates/dashboards/lineage_competition.html
@@ -1,0 +1,105 @@
+{% extends "base.html" %}
+
+{% block content %}
+    <div class="prose max-w-none">
+        <div class="bg-blue-50 border-l-4 border-blue-400 text-blue-800 p-4 my-6" role="status">
+            <p class="m-0"><strong>All data last updated:</strong> TODO</p>
+        </div>
+
+        <p>
+            SARS-CoV-2 is constantly evolving, with new variants competing against one another for domiance in different regions. This model integrates SARS-CoV-2 genotype sequencing data from around the world to estimate the growth advantage of different variants, which is then used to provide regional estimates of variant frequencies and how these are changing over time. This can be used by researchers who might wish to know which variants to focus on in their studies, or by public health officials who might wish to know which variants are likely to become dominant in their region.
+        </p>
+
+        <p>
+            The full set of model estimates, which includes estimates for countries other than Sweden, can be found in the <a href="https://github.com/MurrellGroup/lineages">GitHub repository of the Murrell research group</a>, who conduct this research.
+        </p>
+
+        <h2>Global statistics on lineage competition</h2>
+
+        <h3>Advantage estimates</h3>
+
+        <p>
+            Growth rate advantages are estimated from all variant frequency data, globally. A variant with a higher growth rate advantage is expected to increase in frequency relative to other variants.
+        </p>
+
+        <figure class="my-6">
+            <img alt="Growth advantage estimates for the top variants" src="https://raw.githubusercontent.com/MurrellGroup/lineages/main/plots/pruned_lineages_MCMC_lineage_growths.svg" class="mx-auto max-w-[1000px] w-full h-auto" />
+        </figure>
+
+        <p>
+            For convergent mutations (occuring independently at least three times), the contribution to the growth rate advantage of each mutation is estimated.
+        </p>
+
+        <figure class="my-6">
+            <img alt="Estimates of contribution to growth of convergently occuring mutations" src="https://raw.githubusercontent.com/MurrellGroup/lineages/main/plots/N_MCMC_mutations.svg" class="mx-auto max-w-[1000px] w-full h-auto" />
+        </figure>
+
+        <p>
+            The relatedness of SARS-CoV-2 variants, with their estimated growth rate advantages, can be visualised in a phylogenetic tree. Only recent variants, and key ancestral variants, are shown. Lineages with low growth rate estimates are excluded.
+        </p>
+
+        <figure class="my-6">
+            <img alt="Growth-annotated phylogeny" src="https://raw.githubusercontent.com/MurrellGroup/lineages/main/plots/tree_pruned.svg" class="mx-auto max-w-[1000px] w-full h-auto" />
+        </figure>
+
+        <h3>Variant trajectories</h3>
+
+        <p>
+            The "model average" variant frequencies are forecasts from the model with all region-specific effects set to zero. This provides a single "snapshot" of the global variant situation. This is not meant to representative of the true global variant frequencies, since it is influenced by different sequencing coverage in different regions, but it is useful to understand the model's estimates of how quickly one variant might be expected to replace others.
+        </p>
+
+        <p>
+            Variants are coloured such that related variants should be similar in colour.
+        </p>
+
+        <figure class="my-6">
+            <img alt="Model average variant trajectories" src="https://raw.githubusercontent.com/MurrellGroup/lineages/main/plots/variant_trajectories_model_avg.svg" class="mx-auto max-w-[1000px] w-full h-auto" />
+        </figure>
+
+        <figure class="my-6">
+            <img alt="Model average variant frequencies" src="https://raw.githubusercontent.com/MurrellGroup/lineages/main/plots/muller_trajectories_model_avg.svg" class="mx-auto max-w-[1000px] w-full h-auto" />
+        </figure>
+
+        <h2>Results from Sweden</h2>
+
+        <p>
+            Estimates of variant frequencies and growth rate advantages for Sweden are always included in the model. As with all data used in the model, Swedish genotype data comes from <a href="https://gisaid.org">GISAID</a>. Sequencing volumes are often low for Sweden, especially when the case counts themselves are low (and there are not many infections to sequence). In such cases, the estimates for variant frequencies in Sweden can be very uncertain. It is therefore important to treat the results of the model with caution when sequencing volumes are low.
+        </p>
+
+        <figure class="my-6">
+            <img alt="SARS-CoV-2 genotype volumes" src="https://raw.githubusercontent.com/MurrellGroup/lineages/main/plots/sequence_volume_Sweden.svg" class="mx-auto max-w-[1000px] w-full h-auto" />
+        </figure>
+
+        <figure class="my-6">
+            <img alt="Variant trajectories in Sweden" src="https://raw.githubusercontent.com/MurrellGroup/lineages/main/plots/variant_trajectories_Sweden.svg" class="mx-auto max-w-[1000px] w-full h-auto" />
+        </figure>
+
+        <figure class="my-6">
+            <img alt="Variant frequencies in Sweden" src="https://raw.githubusercontent.com/MurrellGroup/lineages/main/plots/muller_trajectories_country_Sweden.svg" class="mx-auto max-w-[1000px] w-full h-auto" />
+        </figure>
+
+        <h2>Methods</h2>
+
+        <p>
+            Lineage dynamics are modelled using a Bayesian multinomial logistic regression over lineage counts. The latest global <a href="https://gisaid.org/">GISAID</a> SARS-CoV-2 dataset (obtained via bulk download) is filtered to include only sequences with collection dates within the last 100 days. Lineage assignment is performed using <a href="https://docs.nextstrain.org/projects/nextclade/en/stable/user/nextclade-cli/index.html">NextClade</a>, retaining sequences with a “good” overall quality control (QC) status, and >90% coverage. Daily lineage counts are aggregated by region (including only countries with sufficient recent sequencing volumes), with low-frequency sub-lineages (too rare to model) merged into their most recent ancestors.
+        </p>
+
+        <p>
+            Growth rates are modelled with a hierarchical approach. Each lineage's growth rate in a given region is the sum of a global rate and a region-specific random effect. The global rate for each lineage comprises three components: i) branch-specific terms for each branch ancestral to the lineage, ii) terms for convergent spike mutations occurring 3 or more times independently that are present in the lineage, and iii) a lineage-specific term. This parameterisation allows for shared evidence when mutations occur across multiple branches, and phylogenetic heritability of growth rates, such that growth rates for closely-related lineages are more likely, under the model’s prior, to be similar to one another. Recombinants inherit weighted mixtures of their multiple parents' growth terms. Lineage-specific intercept terms, which control the relative timing of the emergence of variants, comprise a global shared term and region-specific random effects.
+        </p>
+
+        <p>
+            Gaussian priors (centred on zero) are used for each parameter type, with Gaussian hyperpriors over the log of their standard deviations. Posterior distributions are jointly sampled (for global and local parameters for all global data) using Hamiltonian Monte Carlo with the No-U-Turn sampler, implemented in the <a href="https://github.com/TuringLang/AdvancedHMC.jl">AdvancedHMC.jl</a> package of <a href="https://julialang.org/">Julia</a>.
+        </p>
+
+        <p>
+            The <a href="https://github.com/cov-lineages/pango-designation/">Pango designations</a> are used for lineage names in all of the plots produced using the model.
+        </p>
+
+        <p>
+            The Murrell group gratefully acknowledges all data contributors, i.e. the Authors and their Originating Laboratories responsible for obtaining the specimens, and their Submitting Laboratories that generated the genetic sequence and metadata and shared via the GISAID Initiative the data on which this research is based.
+        </p>
+    </div>
+{% endblock %}
+
+

--- a/pages/dashboards/urls.py
+++ b/pages/dashboards/urls.py
@@ -1,8 +1,9 @@
 from django.urls import path
-from .views import DashboardsIndex
+from .views import DashboardsIndex, LineageCompetition
 
 app_name = "dashboards"
 
 urlpatterns = [
     path("", DashboardsIndex.as_view(), name="index"),
+    path("lineage-competition/", LineageCompetition.as_view(), name="lineage_competition"),
 ]

--- a/pages/dashboards/views.py
+++ b/pages/dashboards/views.py
@@ -9,3 +9,14 @@ class DashboardsIndex(BaseTemplateView):
 
     template_name = "dashboards/index.html"
     title = "Data dashboards"
+
+
+class LineageCompetition(BaseTemplateView):
+    """SARS-CoV-2 Variant Competition dashboard page."""
+
+    template_name = "dashboards/lineage_competition.html"
+    title = "SARS-CoV-2 Variant Competition"
+    description = (
+        "Estimates of SARS-CoV-2 variant frequencies and growth rate advantages from "
+        "global SARS-CoV-2 genotype sequencing data"
+    )


### PR DESCRIPTION
### 📋 Summary
<!-- Briefly describe WHAT and WHY of this PR -->
This PR replicates the SARS-CoV-2 Variant Competition dashboard.
 
### 🛠️ Changes Made
<!-- One-liners or bullet points -->
- create new view
- update url path
- create dashboard template
- update dashboards index
- improve accessibility

### 🔍 Notes for Reviewers
<!-- Tips, edge cases, or test instructions -->
- Ensure that everything looks correct in `http://localhost:8000/dashboards/lineage-competition/`
 
### ✅ Checklist
- [x] PR title follows the pattern: `FREYA-XXXX: Clear and short description`
- [x] Jira / Github issue is linked in description
- [x] Assignee is selected
- [x] Automated checks pass
- [x] Reviewer is selected when the PR is marked as ready for review

### 🔗 Jira Issue
<!-- Example: FREYA-914 -->
Closes: [FREYA-1680](https://scilifelab.atlassian.net/browse/FREYA-1680)
