### PR TITLE
Set correct 'home' url name

### DIFF
--- a/core/templates/404.html
+++ b/core/templates/404.html
@@ -3,5 +3,5 @@
 {% block content %}
     <p>Sorry, that page cannot be found.</p>
 
-    <p><a href="{% url 'home' %}">Back to the homepage</a></p>
+    <p><a href="{% url 'home:index' %}">Back to the homepage</a></p>
 {% endblock %}


### PR DESCRIPTION
Previously missed to change the `url` name. Thus while the app tries to raise 404, it fails and raises 500 error.