### PR TITLE
Add django-htmx to project

### DIFF
--- a/core/settings/base.py
+++ b/core/settings/base.py
@@ -47,7 +47,9 @@ DJANGO_APPS = [
     "django.contrib.staticfiles",
 ]
 
-THIRD_PARTY_APPS = []
+THIRD_PARTY_APPS = [
+    "django_htmx",
+]
 
 LOCAL_APPS = [
     "pages.articles",
@@ -75,6 +77,7 @@ MIDDLEWARE = [
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
+    "django_htmx.middleware.HtmxMiddleware",
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ requires-python = ">=3.13"
 dependencies = [
     "django>=5.2.4",
     "django-environ>=0.12.0",
+    "django-htmx>=1.27.0",
     "markdown>=3.5.0",
     "pillow>=10.0.0",
     "plotly>=6.4.0",

--- a/uv.lock
+++ b/uv.lock
@@ -81,6 +81,19 @@ wheels = [
 ]
 
 [[package]]
+name = "django-htmx"
+version = "1.27.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asgiref" },
+    { name = "django" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/34/f2/8c3e28a5eed8e5226835c762892bfef74eda7e8629c65b49c186098eb303/django_htmx-1.27.0.tar.gz", hash = "sha256:036e5da801bfdf5f1ca815f21592cfb9f004a898f330c842f15e55c70e301a75", size = 65362, upload-time = "2025-11-28T23:18:55.049Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/23/ac/25d28489dc43224e260f4ebee7565f7ef1efe12af0f284a89500c19f75e2/django_htmx-1.27.0-py3-none-any.whl", hash = "sha256:13e1e13b87d39b57f95aae6e4987cb3df056d0b1373a41f4a94504a00298ffd8", size = 62126, upload-time = "2025-11-28T23:18:53.57Z" },
+]
+
+[[package]]
 name = "gunicorn"
 version = "23.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -314,6 +327,7 @@ source = { virtual = "." }
 dependencies = [
     { name = "django" },
     { name = "django-environ" },
+    { name = "django-htmx" },
     { name = "markdown" },
     { name = "pillow" },
     { name = "plotly" },
@@ -348,6 +362,7 @@ prod = [
 requires-dist = [
     { name = "django", specifier = ">=5.2.4" },
     { name = "django-environ", specifier = ">=0.12.0" },
+    { name = "django-htmx", specifier = ">=1.27.0" },
     { name = "markdown", specifier = ">=3.5.0" },
     { name = "pillow", specifier = ">=10.0.0" },
     { name = "plotly", specifier = ">=6.4.0" },


### PR DESCRIPTION
### 📋 Summary
<!-- Briefly describe WHAT and WHY of this PR -->
This PR add a template with `HTMX` script tag. This can be then be used in other template when need by using django's `include` tag.
 
### 🛠️ Changes Made
<!-- One-liners or bullet points -->
- Added `core/templates/load_htmx.html`

### 🔍 Notes for Reviewers
<!-- Tips, edge cases, or test instructions -->
The idea is instead of doing `<script src="...<version>...htmx.min.js">` in individual template files, we can use `{% include "load_htmx.html" %}` in the templates where it is required.

This way same version is used across the project and easier to update versions by just changing it in one place.

After this is merged, I will update my `SLU ww` PR accordingly.
 
### ✅ Checklist
- [x] Assignee is selected
- [x] Code and content adhere to [conventions](https://scilifelab.atlassian.net/wiki/spaces/CDP2/pages/1909424133/Guidelines+for+the+portal+content)
- [x] Automated checks pass
- [x] Reviewer is selected when the PR is marked as ready for review
