### PR TITLE
FREYA-1958: Add yamllint to pre-commit

### DIFF
--- a/.github/workflows/yamllint.yaml
+++ b/.github/workflows/yamllint.yaml
@@ -29,3 +29,4 @@ jobs:
         uses: ibiqlik/action-yamllint@v3
         with:
           config_file: .github/.yamllint.yaml
+          strict: true  # Default but explicit - fail on warnings too

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,4 +19,4 @@ repos:
     hooks:
       - id: yamllint
         types: [yaml]
-        args: ["-c", ".github/.yamllint.yaml"]
+        args: ["-c", ".github/.yamllint.yaml", "--strict"]


### PR DESCRIPTION
### 📋 Summary
This PR builds on the previously introduced pre-commit hook and adds yamllint. This will work in the same way as the yamllint workflow that is already active in this repo, but will block commits until you have fixed any yaml file issues (or bypass the errors).

### 🛠️ Changes Made
- Added yamllint to pre-commit-config
- Added `strict` to the yamllint workflow - this is the default and current behavior already, but this is to be explicit and so that we know the workflow and pre-commit works the same way and flags the same things

### 🔍 Notes for Reviewers
<!-- Tips, edge cases, or test instructions -->
 
### ✅ Checklist
- [x] PR title follows the pattern: `FREYA-XXXX: Clear and short description`
- [x] Jira / Github issue is linked in description
- [x] Assignee is selected
- [x] Code and content adhere to [conventions](https://scilifelab.atlassian.net/wiki/spaces/CDP2/pages/1909424133/Guidelines+for+the+portal+content)
- [x] Automated checks pass
- [x] Reviewer is selected when the PR is marked as ready for review

### 🔗 Jira Issue
<!-- Example: FREYA-914 -->
Closes: [FREYA-1958](https://scilifelab.atlassian.net/browse/FREYA-1958)
