### PR TITLE
FREYA-1986: Bump Django to >=5.2.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,9 +6,7 @@ readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
     "django>=5.2.8",
-    "django-browser-reload>=1.20.0",
     "django-environ>=0.12.0",
-    "django-extensions>=4.1",
     "django-htmx>=1.27.0",
     "markdown>=3.5.0",
     "pillow>=10.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -432,9 +432,7 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "django" },
-    { name = "django-browser-reload" },
     { name = "django-environ" },
-    { name = "django-extensions" },
     { name = "django-htmx" },
     { name = "markdown" },
     { name = "pillow" },
@@ -471,9 +469,7 @@ prod = [
 [package.metadata]
 requires-dist = [
     { name = "django", specifier = ">=5.2.8" },
-    { name = "django-browser-reload", specifier = ">=1.20.0" },
     { name = "django-environ", specifier = ">=0.12.0" },
-    { name = "django-extensions", specifier = ">=4.1" },
     { name = "django-htmx", specifier = ">=1.27.0" },
     { name = "markdown", specifier = ">=3.5.0" },
     { name = "pillow", specifier = ">=10.0.0" },


### PR DESCRIPTION
### 📋 Summary
The addition of the trivy workflow to this repository produced a warning regarding the django version. The vulnerabilty is in the ORM. 
Some versions are subject to SQL injections due to insufficient validation of the `_connector` argument in a few different `QuerySet` methods and objects. 

https://github.com/ScilifelabDataCentre/swedish-pathogens-portal/security/code-scanning/113

### 🛠️ Changes Made
- Bump minimum version of Django to 5.2.8

### 🔍 Notes for Reviewers
For the django bump I ran:
1. `uv add "django>=5.2.8"`
2. `uv lock --upgrade-package django`

### ✅ Checklist
- [x] PR title follows the pattern: `FREYA-XXXX: Clear and short description`
- [x] Jira / Github issue is linked in description
- [x] Assignee is selected
- [x] Code and content adhere to [conventions](https://scilifelab.atlassian.net/wiki/spaces/CDP2/pages/1909424133/Guidelines+for+the+portal+content)
- [x] Automated checks pass
- [x] Reviewer is selected when the PR is marked as ready for review

### 🔗 Jira Issue
<!-- Example: FREYA-914 -->
Closes: [FREYA-1986](https://scilifelab.atlassian.net/browse/FREYA-1986)
