### PR TITLE
FREYA-1986: Don't scan venvs in branch scan

### DIFF
--- a/.github/workflows/trivy-branch.yaml
+++ b/.github/workflows/trivy-branch.yaml
@@ -41,7 +41,7 @@ jobs:
           output: 'trivy-results.sarif'
           severity: 'CRITICAL,HIGH,MEDIUM'
           exit-code: "1"  # Fail workflow if vulnerabilities found
-          # skip-dirs: "app/.venv"
+          skip-dirs: "app/.venv"
 
       - name: Upload Trivy scan results to GitHub Security tab
         if: always()  # Publish results to security tab even if scan fails


### PR DESCRIPTION
### 📋 Summary
A django-related CSV was resolved in https://github.com/ScilifelabDataCentre/swedish-pathogens-portal/pull/76. This however didn't lead to the auto-fix of the vulnerabilty in the security tab because the trivy scan automatically finds and scans an old venv created by the Dockerfile on publish: `app/.venv`

This PR makes the trivy branch scan ignore the `app/.venv`. Images and actually installed versions will be scanned by the scheduled trivy action, but the branch scan should be scanning our declared package versions since that will let us detect issues early and keep it deterministic and accurate. 
 
### 🛠️ Changes Made
- Ignore `app/.venv` in the trivy branch scan
- Allow download of artifact: The addition to the bottom of the file will let us: `Actions --> [Trivy - branch scan] -->  [workflow run] --> download sarif from Artifacts`. This will let us see the results in the sarif file as well which may help in future debugging.

### 🔍 Notes for Reviewers
Not optimal maybe but this branch still has the same ID as the django vulnerability fix, which is because the task started as explicity fixing the issue of why the auto-fix wasn't happening. It's still partly related since this will help us solve it.

When this is merged I will be manually ignoring the django vulnerability since it is in fact fixed, just that there's no venv accurately representing the latest versions of the packages. 
 
### ✅ Checklist
- [x] PR title follows the pattern: `FREYA-XXXX: Clear and short description`
- [x] Jira / Github issue is linked in description
- [x] Assignee is selected
- [x] Code and content adhere to [conventions](https://scilifelab.atlassian.net/wiki/spaces/CDP2/pages/1909424133/Guidelines+for+the+portal+content)
- [x] Automated checks pass
- [x] Reviewer is selected when the PR is marked as ready for review

### 🔗 Jira Issue
<!-- Example: FREYA-914 -->
Closes: [FREYA-1986](https://scilifelab.atlassian.net/browse/FREYA-1986)
