### PR TITLE
FREYA-1987: Add upgrade for future vulnerabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -101,7 +101,6 @@ FROM base AS build
 
 # Build dependencies for psycopg[c]
 RUN apt-get update --quiet --assume-yes \
- && apt-get upgrade --quiet --assume-yes \
  && apt-get install --quiet --assume-yes --no-install-recommends \
         gcc \
         libc6-dev \


### PR DESCRIPTION
### 📋 Summary
This PR started out as a fix of https://avd.aquasec.com/nvd/2023/cve-2023-45853/ (https://github.com/ScilifelabDataCentre/swedish-pathogens-portal/security/code-scanning/112) but we actually have nothing to fix (more info below), so instead this adds an upgrade in the Dockerfile so that we do potentially avoid future vulnerabilities.
 
CVE-2023-45853 is a vulnerability in MiniZip, not zlib, and MiniZip is not shipped with debian bookworm zlib1g. 

> src:zlib only starts building minizip starting in 1:1.2.13.dfsg-2
> For older suites due to this an update can be ignored as no binary package built
> by the vulnerable source is affected (i.e. contrib/minizip not built and provided
> in those versions).
> Source: [Debian Security Tracker](https://security-tracker.debian.org/tracker/CVE-2023-45853)

I will be dismissing `CVE-2023-45853`. 

### 🛠️ Changes Made
- Add `apt-get upgrade` in 2 places in order to make sure we have the latest security-patched versions available for the debian release used.

### 🔍 Notes for Reviewers
It's not a must to add this but it does mean we apply the debian security updates automatically during image build. However it could potentially make it less reproducible since it's always the latest. 
 
### ✅ Checklist
- [x] PR title follows the pattern: `FREYA-XXXX: Clear and short description`
- [x] Jira / Github issue is linked in description
- [x] Assignee is selected
- [x] Code and content adhere to [conventions](https://scilifelab.atlassian.net/wiki/spaces/CDP2/pages/1909424133/Guidelines+for+the+portal+content)
- [x] Automated checks pass
- [x] Reviewer is selected when the PR is marked as ready for review

### 🔗 Jira Issue
<!-- Example: FREYA-914 -->
Closes: [FREYA-1987](https://scilifelab.atlassian.net/browse/FREYA-1987)
