### PR TITLE
FREYA-1990: Allow manual trigger of trivy

### DIFF
--- a/.github/workflows/trivy-branch.yaml
+++ b/.github/workflows/trivy-branch.yaml
@@ -8,6 +8,7 @@
 name: Trivy - branch scan
 
 on:
+  workflow_dispatch:
   pull_request:
   push:
     branches: [main]


### PR DESCRIPTION
### 📋 Summary
While working on solving the security vulnerabilities reported by Trivy, I found that it would be useful to be able to manually run the action so that we can auto-fix some of the reports.
 
### 🛠️ Changes Made
Added the `workflow_dispatch` trigger to the trivy action.

### 🔍 Notes for Reviewers
<!-- Tips, edge cases, or test instructions -->
 
### ✅ Checklist
- [x] PR title follows the pattern: `FREYA-XXXX: Clear and short description`
- [x] Jira / Github issue is linked in description
- [x] Assignee is selected
- [x] Code and content adhere to [conventions](https://scilifelab.atlassian.net/wiki/spaces/CDP2/pages/1909424133/Guidelines+for+the+portal+content)
- [x] Automated checks pass
- [x] Reviewer is selected when the PR is marked as ready for review

### 🔗 Jira Issue
<!-- Example: FREYA-914 -->
Closes: [FREYA-1990](https://scilifelab.atlassian.net/browse/FREYA-1990)
