### PR TITLE
FREYA-1993: Bump base image to trixie

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG PYTHON_IMAGE=python:3.13-slim-bookworm
+ARG PYTHON_IMAGE=python:3.13-slim-trixie
 
 ###############################################################################
 #                             Base Stage                                      #


### PR DESCRIPTION
### 📋 Summary
While working on solving the security alerts on spp found by trivy scan, there are some CVEs that don’t have a fix in bookworm and that debian has issued a no-dsa (minor issue) on, meaning that they will not be issuing a security release for those CVEs. The discussion was to either accept the small risk or remove the affected packages, but a suggestion was to upgrade to trixie instead for the base image. Debian Bookworm is reaching EOL 2026, while trixie is LTS until 2030. 

This PR upgrades the base image to trixie.
 
### 🛠️ Changes Made
`bookworm` --> `trixie` in Dockerfile base image.

### 🔍 Notes for Reviewers
- I decided to keep it as `slim` and as `python:3.13` for now, but we can bump that later as well if wanted / needed. 
- Trixie introduces a lot of `*t64`-renamed libraries, but I've checked in the container and the relevant packages are still called the same as before, e.g. `libpq5`. So as far as I can see, we don't need to update anything regarding that installation in the Dockerfile. 
- This also fixes CVE-2023-2953:
    - https://github.com/ScilifelabDataCentre/swedish-pathogens-portal/security/code-scanning/47
    - https://security-tracker.debian.org/tracker/CVE-2023-2953 
 
### ✅ Checklist
- [x] PR title follows the pattern: `FREYA-XXXX: Clear and short description`
- [x] Jira / Github issue is linked in description
- [x] Assignee is selected
- [x] Code and content adhere to [conventions](https://scilifelab.atlassian.net/wiki/spaces/CDP2/pages/1909424133/Guidelines+for+the+portal+content)
- [x] Automated checks pass
- [x] Reviewer is selected when the PR is marked as ready for review

### 🔗 Jira Issue
<!-- Example: FREYA-914 -->
Closes: [FREYA-1993](https://scilifelab.atlassian.net/browse/FREYA-1993)
