### PR TITLE
Fix contact url name

### DIFF
--- a/core/templates/footer.html
+++ b/core/templates/footer.html
@@ -21,7 +21,7 @@
                     aria-label="Footer links">
                     <a href="{% url 'about:index' %}">About</a>
                     <span class="select-none" aria-hidden="true">·</span>
-                    <a href="{% url 'contact:contact' %}">Contact</a>
+                    <a href="{% url 'contact:index' %}">Contact</a>
                     <span class="select-none" aria-hidden="true">·</span>
                     <a href="{% url 'citation:index' %}">Cite us</a>
                     <span class="select-none" aria-hidden="true">·</span>

--- a/core/templates/header.html
+++ b/core/templates/header.html
@@ -133,7 +133,7 @@
                             <a href="{% url 'about:index' %}" role="menuitem">About Swedish Pathogens Portal</a>
                             <a href="{% url 'about:funders' %}" role="menuitem">Funders</a>
                             <a href="{% url 'about:partners' %}" role="menuitem">Partners</a>
-                            <a href="{% url 'contact:contact' %}" role="menuitem">Contact Us</a>
+                            <a href="{% url 'contact:index' %}" role="menuitem">Contact Us</a>
                         </div>
                     </div>
                 </div>
@@ -274,7 +274,7 @@
                             <li><a href="{% url 'about:index' %}">About Swedish Pathogens Portal</a></li>
                             <li><a href="{% url 'about:funders' %}">Funders</a></li>
                             <li><a href="{% url 'about:partners' %}">Partners</a></li>
-                            <li><a href="{% url 'contact:contact' %}">Contact Us</a></li>
+                            <li><a href="{% url 'contact:index' %}">Contact Us</a></li>
                         </ul>
                     </details>
                 </div>

--- a/pages/contact/tests.py
+++ b/pages/contact/tests.py
@@ -30,7 +30,7 @@ class ContactFormTests(TestCase):
     def setUp(self) -> None:
         """Initialise test client for each test."""
         self.client = Client()
-        self.url = reverse("contact:contact")
+        self.url = reverse("contact:index")
 
     def _get_tokens_from_response(self, response: HttpResponse) -> tuple[str | None, str | None]:
         """Extract hidden anti-spam token values from rendered HTML.

--- a/pages/contact/views.py
+++ b/pages/contact/views.py
@@ -30,7 +30,7 @@ class ContactFormView(FormView):
 
     template_name = "contact/contact_form.html"
     form_class = ContactForm
-    success_url = reverse_lazy("contact:contact")
+    success_url = reverse_lazy("contact:index")
     title = "Contact and suggestions form"
     logger = logger
 


### PR DESCRIPTION
The landing page url is changed from `contact` to `index` for consistency across app. But the branch of merged PR #92 still referred `contact:contact` thus breaking the site. 