### PR TITLE
update dependancy to django >= 6.0.2

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -514,7 +514,7 @@ prod = [
 
 [package.metadata]
 requires-dist = [
-    { name = "django", specifier = ">=5.2.8" },
+    { name = "django", specifier = ">=6.0.2" },
     { name = "django-environ", specifier = ">=0.12.0" },
     { name = "django-htmx", specifier = ">=1.27.0" },
     { name = "fastexcel", specifier = ">=0.18.0" },


### PR DESCRIPTION
Minimum version of `django` is updated to `6.0.2` in #96 , so the `uv.lock` should also be updated accordingly.

**THIS IS URGENT AS WE CAN'T GENERATE NEW IMAGE**