### PR TITLE
Upgrade openssl for security patches in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,11 +18,15 @@ SHELL ["sh", "-exc"]
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Install curl and CA certs, clean in same layer (no development tools here)
+# Explicitly upgrade openssl to ensure latest security patches (CVE-2025-15467)
+# https://github.com/ScilifelabDataCentre/swedish-pathogens-portal/security/code-scanning/156
 RUN apt-get update --quiet --assume-yes \
  && apt-get upgrade --quiet --assume-yes \
  && apt-get install --quiet --assume-yes --no-install-recommends \
         curl \
         ca-certificates \
+        openssl \
+        openssl-provider-legacy \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
@@ -144,11 +148,15 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
     PATH=/app/.venv/bin:$PATH
 
 # Install runtime libraries required by psycopg[c] and clean up
+# Explicitly upgrade openssl to ensure latest security patches (CVE-2025-15467)
+# https://github.com/ScilifelabDataCentre/swedish-pathogens-portal/security/code-scanning/156
 RUN apt-get update --quiet --assume-yes \
  && apt-get upgrade --quiet --assume-yes \
  && apt-get install --quiet --assume-yes --no-install-recommends \
         libpq5 \
         ca-certificates \
+        openssl \
+        openssl-provider-legacy \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 


### PR DESCRIPTION
### 📋 Summary
<!-- Briefly describe WHAT and WHY of this PR -->
This PR is an attempt at fixing [critical issue #156](https://github.com/ScilifelabDataCentre/swedish-pathogens-portal/security/code-scanning/156).

Package: openssl-provider-legacy
Severity: CRITICAL
Link: [CVE-2025-15467](https://avd.aquasec.com/nvd/cve-2025-15467)

The vulnerable openssl version comes from the base debian image.
 
### 🛠️ Changes Made
<!-- One-liners or bullet points -->
Explicitly install `openssl` in Dockerfile (base and build stages) to force last patched version.

### 🔍 Notes for Reviewers
<!-- Tips, edge cases, or test instructions -->
- I'm not using docker locally, so can you please A/B test openssl version between prior Dockerfile and this one?
- openssl version should be `3.5.4-1~deb13u2`
- References: [Debian package detail](https://packages.debian.org/trixie/openssl), [Debian security tracker](https://security-tracker.debian.org/tracker/CVE-2025-15467)
- Upon testing, if openssl version is already `3.5.4-1~deb13u2` after clearing docker cache and building fresh without the changes from this PR, we'll simply close it.
 
### 🔗 Security Vulnerability
<!-- Example: FREYA-914 -->
Closes: [SECURITY-156](https://github.com/ScilifelabDataCentre/swedish-pathogens-portal/security/code-scanning/156)
