### PR TITLE
Hotfix - Making sure the correct view is called from the download page

### DIFF
--- a/pages/portal_data/templates/portal_data/study_files.html
+++ b/pages/portal_data/templates/portal_data/study_files.html
@@ -7,7 +7,7 @@
   <header class="mb-6 lg:mb-8">
     <h1>Files for {{ accession }}</h1>
     <p class="text-sm text-pp-dark-grey">Browse and download individual files from the PVC.</p>
-    <a href="{% url 'portal_data:data_type_list' datatype=datatype %}" class="text-sm underline">Back to list</a>
+    <a href="{% url 'portal_data:index' datatype=datatype %}" class="text-sm underline">Back to list</a>
   </header>
 
   <div class="rounded border border-pp-pale-grey bg-white p-4 shadow-sm">


### PR DESCRIPTION
### 📋 Summary
<!-- Briefly describe WHAT and WHY of this PR -->
This PR fixes the Portal_data app by updating the `study_files.html` to use the URL `index` for the view `DataTypeList` which was changed during the review of #79 
 

### 🔍 Notes for Reviewers
<!-- Tips, edge cases, or test instructions -->
 
### ✅ Checklist
- [ ] PR title follows the pattern: `FREYA-XXXX: Clear and short description`
- [ ] Jira / Github issue is linked in description
- [ ] Assignee is selected
- [ ] Code and content adhere to [conventions](https://scilifelab.atlassian.net/wiki/spaces/CDP2/pages/1909424133/Guidelines+for+the+portal+content)
- [ ] Automated checks pass
- [ ] Reviewer is selected when the PR is marked as ready for review

### 🔗 Jira Issue
<!-- Example: FREYA-914 -->
Closes: [FREYA-XXXX](https://scilifelab.atlassian.net/browse/FREYA-XXXX)
