### PR TITLE
Add 'highlights_and_editorials' to sitemap

### DIFF
--- a/core/sitemaps.py
+++ b/core/sitemaps.py
@@ -53,11 +53,11 @@ class SPPAutoSitemap(Sitemap):
 
     PUBLIC_APPS = [
         "about",
-        "articles",
         "catalogue",
         "citation",
         "contact",
         "dashboards",
+        "highlights_and_editorials",
         "home",
         "news",
         "outbreaks",


### PR DESCRIPTION
For to fix `sitemap` while renaming `article` to `highlights_and_editorials` in PR #104 
