### PR TITLE
Add other node page to about menu

### DIFF
--- a/core/templates/header.html
+++ b/core/templates/header.html
@@ -154,6 +154,7 @@
                             <a href="{% url 'about:index' %}" role="menuitem">About Swedish Pathogens Portal</a>
                             <a href="{% url 'about:funders' %}" role="menuitem">Funders</a>
                             <a href="{% url 'about:partners' %}" role="menuitem">Partners</a>
+                            <a href="{% url 'about:nodes' %}" role="menuitem">Other National Nodes</a>
                             <a href="{% url 'contact:index' %}" role="menuitem">Contact Us</a>
                         </div>
                     </div>
@@ -305,6 +306,7 @@
                             <li><a href="{% url 'about:index' %}">About Swedish Pathogens Portal</a></li>
                             <li><a href="{% url 'about:funders' %}">Funders</a></li>
                             <li><a href="{% url 'about:partners' %}">Partners</a></li>
+                            <li><a href="{% url 'about:nodes' %}">Other National Nodes</a></li>
                             <li><a href="{% url 'contact:index' %}">Contact Us</a></li>
                         </ul>
                     </details>


### PR DESCRIPTION
The other national nodes page was missed previously while adding the header menu.