### PR TITLE
Option to open external url in new tab

### DIFF
--- a/core/templates/components/content_card.html
+++ b/core/templates/components/content_card.html
@@ -1,4 +1,4 @@
-{# Required: url, image, title, description. Optional: image_alt, date (j F Y), badge_text, topics. #}
+{# Required: url, image, title, description. Optional: image_alt, external_url, date (j F Y), badge_text, topics. #}
 
 {% load static %}
 
@@ -7,7 +7,8 @@
     <div class="group bg-white rounded-xl overflow-hidden transition-shadow h-full
     shadow-[0_1px_2px_0_rgb(0_0_0/0.1),0_-1px_2px_0_rgb(0_0_0/0.1)]
     hover:shadow-[0_4px_6px_-1px_rgb(0_0_0/0.1),0_2px_4px_-2px_rgb(0_0_0/0.1),0_-4px_6px_-1px_rgb(0_0_0/0.1),0_-2px_4px_-2px_rgb(0_0_0/0.1)]">
-        <a href="{{ url }}" class="no-underline hover:no-underline rounded-xl"
+        <a href="{{ url }}" {% if external_url %}target="_blank" rel="noopener noreferrer"{% endif %}
+        class="no-underline hover:no-underline rounded-xl"
         aria-label="{{ title }}">
             <!-- Image -->
             <div class="overflow-hidden border-b border-pp-pale-grey">

--- a/pages/catalogue/templates/catalogue/partials/resource_grid.html
+++ b/pages/catalogue/templates/catalogue/partials/resource_grid.html
@@ -1,7 +1,7 @@
 {% if catalogue_entries %}
     <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 lg:gap-6">
         {% for item in catalogue_entries %}
-            {% include "components/content_card.html#content_card" with title=item.title image=item.image_url description=item.description url=item.link %}
+            {% include "components/content_card.html#content_card" with title=item.title image=item.image_url description=item.description url=item.link external_url=True only %}
         {% endfor %}
     </div>
 {% else %}

--- a/pages/dashboards/templates/dashboards/external_dashboards.html
+++ b/pages/dashboards/templates/dashboards/external_dashboards.html
@@ -14,7 +14,7 @@
     <p>Below is a list of dashboards created by other organisations that show infectious disease-related data from Sweden.</p>
     <div class="grid sm:grid-cols-2 lg:grid-cols-3 gap-4 lg:gap-6">
         {% for dashboard in external_dashboards|dictsort:"name" %}
-            {% include "components/content_card.html#content_card" with url=dashboard.url image=dashboard.image title=dashboard.name description=dashboard.description only %}
+            {% include "components/content_card.html#content_card" with url=dashboard.url external_url=True image=dashboard.image title=dashboard.name description=dashboard.description only %}
         {% endfor %}
     </div>
 


### PR DESCRIPTION
@Ziip-dev noted a good point that the card partial added in #108 opens the given url in the same tab. But there are apps that uses external links for the cards and desired to be opened in new tab.

This PR enables it by passing additional param `external_url=True` to the partial.
