### PR TITLE
Move 'static()' into a method call

### DIFF
--- a/pages/dashboards/views/external_dashboards.py
+++ b/pages/dashboards/views/external_dashboards.py
@@ -14,11 +14,13 @@ class ExternalDashboards(BaseTemplateView):
     template_name = "dashboards/external_dashboards.html"
     title = "Data dashboards"
     page_heading = "External Dashboards"
+
     # This is a temporary workaround for the MVP, the following dict
     # might be removed and the info will be fetched from DB.
-    extra_context = {
-        # a list of EXTERNAL dashboards
-        "external_dashboards": [
+    def get_context_data(self, **kwargs) -> dict:
+        """Add external dashboards info to context."""
+        context = super().get_context_data(**kwargs)
+        context["external_dashboards"] = [
             {
                 "name": "SvarmIT: interactive resistance monitoring",
                 "image": static("dashboards/thumbnails/external/sva_logo.png"),
@@ -158,5 +160,5 @@ class ExternalDashboards(BaseTemplateView):
                     "in the context of worldwide TB diversity. "
                 ),
             },
-        ],
-    }
+        ]
+        return context

--- a/pages/dashboards/views/index.py
+++ b/pages/dashboards/views/index.py
@@ -18,9 +18,10 @@ class DashboardsIndex(BaseTemplateView):
 
     # This is a temporary workaround for the MVP, the following dict
     # might be removed and the info will be fetched from DB.
-    extra_context = {
-        # a list of ACTIVE dashboards
-        "active_dashboards": [
+    def get_context_data(self, **kwargs) -> dict:
+        """Add dashboards info to context."""
+        context = super().get_context_data(**kwargs)
+        context["active_dashboards"] = [
             {
                 "name": "SLU-SEEC Wastewater Surveillance",
                 "image": static("dashboards/thumbnails/slu_wastewater.jpg"),
@@ -81,9 +82,9 @@ class DashboardsIndex(BaseTemplateView):
                     "about externally produced antigens is also provided. "
                 ),
             },
-        ],
+        ]
         # a list of HISTORIC dashboards
-        "historic_dashboards": [
+        context["historic_dashboards"] = [
             {
                 "name": "COVID Symptom Study Sweden (Partner)",
                 "image": static("dashboards/thumbnails/symptom_study_sweden.jpg"),
@@ -203,5 +204,5 @@ class DashboardsIndex(BaseTemplateView):
                     "samples from surrounding municipalities."
                 ),
             },
-        ],
-    }
+        ]
+        return context


### PR DESCRIPTION
Having `static()` call in attribute level fails in _production_ because the _static_ file lookup would fail as the files would have not been collected.

So moving them into `get_context_data()` will prevent the calling of `static()` on app's startup but only on runtime i.e. during relevant page visit etc. But the _staticfiles_ would have collected after the app is started.