### PR TITLE
Move legend down

### DIFF
--- a/pages/dashboards/visualisation/slu_ww.py
+++ b/pages/dashboards/visualisation/slu_ww.py
@@ -572,7 +572,7 @@ def get_all_sites_plot(
         hoverdistance=1,
         annotations=annotations,
         updatemenus=updatemenus,
-        legend={"font": {"size": 10}},
+        legend={"font": {"size": 10}, "y": 0.95},
         margin=zero_margin,
     )
 
@@ -782,7 +782,7 @@ def get_qual_plots(data: pd.DataFrame | dict, virus: str, as_json: bool = False)
         bargap=0,
         annotations=annotations,
         updatemenus=updatemenus,
-        legend=base_legend,
+        legend={**base_legend, "y": 0.95},
         hoverlabel={"bgcolor": bgcolor},
         margin=zero_margin,
     )


### PR DESCRIPTION
### 📋 Summary
<!-- Briefly describe WHAT and WHY of this PR -->
This PR moves/places the legend slightly down the y-axis so it doesn't overlap with the model bar when hovered.
 
### ✅ Checklist
- [x] Assignee is selected
- [x] Code and content adhere to [conventions](https://scilifelab.atlassian.net/wiki/spaces/CDP2/pages/1909424133/Guidelines+for+the+portal+content)
- [x] Automated checks pass
- [x] Reviewer is selected when the PR is marked as ready for review
