### PR TITLE
Run trivy branch action only on certain files modification

### DIFF
--- a/.github/workflows/trivy-branch.yaml
+++ b/.github/workflows/trivy-branch.yaml
@@ -10,8 +10,18 @@ name: Trivy - branch scan
 on:
   workflow_dispatch:
   pull_request:
+    paths:
+      - '.python-version'
+      - 'Dockerfile'
+      - 'pyproject.toml'
+      - 'uv.lock'
   push:
     branches: [main]
+    paths:
+      - '.python-version'
+      - 'Dockerfile'
+      - 'pyproject.toml'
+      - 'uv.lock'
 
 concurrency:
   group: trivy-${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Currently `trivy` branch scan is trigged for any file change, this change will make it trigger only if the files of interest is modified.